### PR TITLE
Minor language tweaks

### DIFF
--- a/week01/day01/README.md
+++ b/week01/day01/README.md
@@ -1,5 +1,5 @@
-# Day #1 - Calling functions with literals
-Let's start our F# journey with the obligatory "Hello, World!" program ;-) Here's how it looks in the online F# editor at [tryfsharp.org](http://www.tryfsharp.org/Create):
+# Day #1 – Calling functions with literals
+Let's start our F# journey with the obligatory "Hello, World!" program ;-). Here's how it looks in the online F# editor at [tryfsharp.org](http://www.tryfsharp.org/Create):
 
 ![](images/w01d01a.png)
 
@@ -11,27 +11,27 @@ If you use `printf` (without the "n") then there will be no line break between s
 
 ![](images/w01d01c.png)
 
-This is nifty, you might say ;-) But what is this `unit = ()` thing after the output? Function calls in F# always return a value; or even: everything in F# produces a value. But what kind of result should `printf` produce? It's purpose is to produce a side effect on standard output. Nevertheless it produces a result of type `unit`; think of it as a "never mind" result. That's what the last line of the output is about. We'll get to that on a later day. For now ignore it.
+This is nifty, you might say ;-). But what is this `unit = ()` thing after the output? Function calls in F# always return a value; or even: everything in F# produces a value. But what kind of result should `printf` produce? Its purpose is to produce a side effect on standard output. Nevertheless, it produces a result of type `unit`; think of it as a "never mind" result. That's what the last line of the output is about. We'll get to that on a later day. For now, ignore it.
 
 ## Simple function calls
-This was easy - as it was supposed to be. Still there is something to learn here: How to call a function in the Functional Programming language of F#.
+This was easy – as it was supposed to be. Still, there is something to learn here: how to call a function in the functional programming language of F#.
 
-Just write the name of the function - `printfn` in this example - followed by any parameters. No parentheses, no delimiters except spaces are required. (However, `printfn ("Hello, World!")` would work just fine, too.)
+Just write the name of the function – `printfn` in this example – followed by any parameters. No parentheses, no delimiters except spaces are required. (However, `printfn ("Hello, World!")` would work just fine, too.)
 
-Let's try this with 2 parameters:
+Let's try this with two parameters:
 
 ```fsharp
 printfn "Hello, %s!" "Peter"
 ```
 
-Since the format string contains a placeholder (`"%s"`) the function expects another parameter to insert into the output which becomes `Hello, Peter!`.
+Since the format string contains a placeholder (`"%s"`), the function expects another parameter to insert into the output, which becomes `Hello, Peter!`.
 
 Common placeholders are:
 
 * %s for strings
 * %d for signed integers
-* %X for upper case hexadecimal output of integers
-* %f for floating point numbers
+* %X for upper-case hexadecimal output of integers
+* %f for floating-point numbers
 * %b for boolean values, prints `true` or `false`
 * %A for non-primitive typed data, e.g. lists
 
@@ -39,7 +39,7 @@ Common placeholders are:
 
 Read more about placeholders and output formatting in the [printf documentation](https://msdn.microsoft.com/en-us/library/ee370560.aspx).
 
-Finally a function call with even more parameters:
+Finally, a function call with even more parameters:
 
 ```fsharp
 printfn "%s, %d, %f, %b" "Hello!" 42 3.1415 true
@@ -48,7 +48,7 @@ printfn "%s, %d, %f, %b" "Hello!" 42 3.1415 true
 ## Literals
 The second thing to learn from the use of `printfn` is: literals. There are certain rules for how to format literal values in F# code. They are simple, but they exist nonetheless.
 
-Above you've already seen a couple of literals. Each is associated with a data type, e.g.
+Above, you've already seen a couple of literals. Each is associated with a data type, e.g.
 
 * `"Hello!"` is a `string`
 * `42` is an `int`
@@ -58,13 +58,13 @@ Above you've already seen a couple of literals. Each is associated with a data t
 But there are additional primitive types with formatting rules for their literal values, e.g. `char`, `byte`, or `bigint`.
 
 ### Strings
-Strings are sequences of characters. If there is just one character then use `'` (single quote) to enclose it, e.g. `'a'`. If there are more than one then use `"` (double quote), e.g. `"abc"`.
+Strings are sequences of characters. If there is just one character then use `'` (single quote) to enclose it, e.g. `'a'`. If there are more than one, use `"` (double quote), e.g. `"abc"`.
 
 Special characters are represented by prefixing an ordinary character with a `\`, e.g. `'\t'` (TAB) or `"Hello, \nWorld!"` (line break).
 
-If you want to use the backslash in your string prepend a `@`, e.g. `@"c:\windows"`.
+If you want to use the backslash in your string, prepend a `@`, e.g. `@"c:\windows"`.
 
-By default strings and characters are encoded using Unicode. If you like them to be ASCII append a `B` at the end, e.g. `'a'B` or `"abc"B`. This gets them to be stored as `byte` and `byte[]` (`byte` array).
+By default, strings and characters are encoded using Unicode. If you would like them to be ASCII, append a `B` at the end, e.g. `'a'B` or `"abc"B`. This causes them to be stored as `byte` and `byte[]` (`byte` array).
 
 ```fsharp
 printfn "%A, %A, %A, %A" 'a' 'a'B "abc" "abc"B
@@ -79,14 +79,14 @@ prints
 (The special character sequences `[|` and `|]` enclose elements of an array.)
 
 ### Numbers
-Without any other hint numbers are stored as `int` and `float`, e.g. `123`, `3.1415`. But you can change that with a suffix:
+Without any other hint, numbers are stored as `int` and `float`, e.g. `123`, `3.1415`. But you can change that with a suffix:
 
 * `y`: store as `sbyte`, e.g. `65y`
 * `uy`: store as `byte`, e.g. `255uy`
 * `s` / `us`: store as `int16`, `uint16`, e.g. `86s`, `86us`
 * `I`: store as `bigint` for an arbitrarily large integer number, e.g. `123456789987654321999999999I`
 
-Also you can enter integer values in different numerical systems by prefixing them with `0` and a letter, e.g.
+Also, you can enter integer values in different numerical systems by prefixing them with `0` and a letter, e.g.
 
 * `b`: binary, `0b10101`
 * `x`: hexadecimal, `0xFE`
@@ -100,4 +100,4 @@ Read more about literals [here](https://msdn.microsoft.com/en-us/library/vstudio
 
 ***
 
-So much for your first day of F#. Now you can write small programs sending greetings of all sorts to the world ;-)
+So much for your first day of F#. Now you can write small programs sending greetings of all sorts to the world ;-).

--- a/week01/day02/README.md
+++ b/week01/day02/README.md
@@ -1,5 +1,5 @@
-# Day #2 - Operators are functions
-Yesterday you learned how to call a simple function to write data to standard output. So far the data were constant values given as literals of different primitive data types.
+# Day #2 – Operators are functions
+Yesterday, you learned how to call a simple function to write data to standard output. So far, the data were constant values given as literals of different primitive data types.
 
 Today is going to change that. Enter the world of data transformation using operators.
 
@@ -7,11 +7,11 @@ Operators in F# are just functions. You want to add two numbers? Use the `+` ope
 
 ![](images/w01d02a.png)
 
-It's the same like with `printf`: a function name followed by parameters - just like that.
+It's the same as with `printf`: a function name followed by arguments – just like that.
 
 However, F# needs an operator function name to be enclosed in parentheses. That's because it consists of special characters, not letters.
 
-Or to be more precise: F# needs the parentheses if you put the operator function name first like above. This works with other operators too:
+Or to be more precise: F# needs the parentheses if you put the operator function name first, like above. This works with other operators too:
 
 ```fsharp
 (-) 3 2
@@ -23,9 +23,9 @@ Or to be more precise: F# needs the parentheses if you put the operator function
 (<>) 7 2 // not equal
 ```
 
-You see, F# supports all sorts of common operators in usual form. But note a couple of things:
+You see, F# supports all sorts of common operators in their usual form. But note a couple of things:
 
-First, both parameters to binary operators must be of the same type. See `/` above. If you tried
+First, both parameters of binary operators must be of the same type. See `/` above. If you tried
 
 ```fsharp
 (/) 3.0 2 // does not compile
@@ -33,13 +33,13 @@ First, both parameters to binary operators must be of the same type. See `/` abo
 
 it wouldn't work.
 
-Second, F# uses `=` for equality comparison, not `==` as C#.
+Second, F# uses `=` for equality comparison, not `==` like C#.
 
-There are of course many more operators. See [here](https://msdn.microsoft.com/en-us/library/dd233228.aspx) for a full list. Among them for example the power operator `**`.
+There are of course many more operators. See [here](https://msdn.microsoft.com/en-us/library/dd233228.aspx) for a full list. Among them, for example, the power operator `**`.
 
-It cannot be used like the other ones in parentheses, because `(*` and `*)` enclose multi-line comments. Single line comments start with `//` as you've seen above.
+It cannot be used like the other ones in parentheses, because `(*` and `*)` enclose multi-line comments. Single line comments start with `//`, as you've seen above.
 
-But help is on its way. Or did you believe F# required you to use operators in such a cumbersome way? ;-) Of course it's possible to use binary operators as usual with infix notation:
+But help is on its way. Or did you believe F# requires you to use operators in such a cumbersome way? ;-) Of course it's possible to use binary operators as usual, with infix notation:
 
 ```fsharp
 3 + 2
@@ -53,19 +53,19 @@ But help is on its way. Or did you believe F# required you to use operators in s
 3.0 ** 2.0 // to the power of
 ```
 
-Also as usual F# assigns operators a precedence:
+Also as usual, F# assigns operators a precedence:
 
 ```fsharp
 1.0 + 2.0 * 3.0 ** 4.0 = 163.0
 ```
 
-So far you've primarily seen numeric operators and some boolean operators. Operators exist for other values, too, though. Use `+` to concatenate strings, for example:
+So far you've primarily seen numeric operators and some boolean operators. Operators exist for other values too, though. Use `+` to concatenate strings, for example:
 
 ```fsharp
 "Hello, " + "World!"
 ```
 
-Later you'll learn about more operators for other types. Some are binary, some ternary, some unary like
+Later you'll learn about more operators for other types. Some are binary, some ternary, some unary, like
 
 ```fsharp
 -2
@@ -81,21 +81,21 @@ Even though operators have their precendences, sometimes there is need for paren
 
 ```
 
-To finish your day's portion of F# here's how to print the results of expressions:
+To finish your day's portion of F#, here's how to print the results of expressions:
 
 ```fsharp
 printfn "%d" ((+) 3 2)
 printfn "%f" (3.0 ** 2.0)
 ```
 
-Regardless whether you apply operators in prefix or infix form you need to enclose the function calls in parentheses for output to the console. That way the compiler can tell `(3.0 ** 2.0)` to produce the value for the second parameter to `printfn`.
+Regardless of whether you apply operators in prefix or infix form, you need to enclose the function calls in parentheses for output to the console. That way, the compiler can tell `(3.0 ** 2.0)` to produce the value for the second argument to `printfn`.
 
-The reason: Function calls are left associative. To F# `printfn "%d" 3 + 2` looks like `4 + 3 + 2` where `4 + 3` is evaluated first leading to `7 + 2` being evaluated second. But `printfn "%d" 3` results in `unit` leading to `unit + 2` which does not make sense. That's what the following error message means:
+The reason: function calls are left-associative. To F# `printfn "%d" 3 + 2` looks like `4 + 3 + 2`, where `4 + 3` is evaluated first, leading to `7 + 2` being evaluated second. But `printfn "%d" 3` results in `unit`, leading to `unit + 2`, which does not make sense. That's what the following error message means:
 
 ![](images/w01d02b.png)
 
-To avoid this, put expression parameters in parentheses so the expressions get evaluated first like in `4 * (3 + 2)`.
+To avoid this, put expression arguments in parentheses so that the expressions get evaluated first, like in `4 * (3 + 2)`.
 
 ***
 
-That's it for your second day of F#. Let F# do the math for you from now on ;-)
+That's it for your second day of F#. Let F# do the math for you from now on ;-).

--- a/week01/day03/README.md
+++ b/week01/day03/README.md
@@ -1,15 +1,15 @@
-# Day #3 - Functions as values
-So far you have seen how to use some existing functions in F#. Now it's time to learn how to define your own. Enter: function literals.
+# Day #3 – Functions as values
+So far, you have seen how to use some existing functions in F#. Now it's time to learn how to define your own. Enter: function literals.
 
-In Functional Programming languages functions are values like integers and strings. That means their values can also be written "inline". Here's a simple example:
+In functional programming languages, functions are values like integers and strings. That means their values can also be written "inline". Here's a simple example:
 
 ```fsharp
 fun x y -> x + y
 ```
 
-Yes, that's a function literal, it describes a value like `3.14` or `true` do. This value can be passed around like a `float` or a `bool` value. Think of it as an array of bytes containing executable code.
+Yes, that's a function literal; it describes a value like `3.14` or `true` do. This value can be passed around like a `float` or a `bool` value. Think of it as an array of bytes containing executable code.
 
-The syntax for function literals (or lambda expression) is:
+The syntax for function literals (or lambda expressions) is:
 
 ```
 "fun" { formal_parameter } "->" function_body
@@ -21,7 +21,7 @@ A value of a primitive type is just inert data. But a function value can become 
 (fun x y -> x + y) 2 3
 ```
 
-Like with an operator put the function literal in parentheses and pass values for its formal parameters.
+Like with an operator, put the function literal in parentheses and pass values for its formal parameters.
 
 Here's another example, this time including a result display on standard output. Do you recognize the operation?
 
@@ -31,18 +31,18 @@ printfn "%b" ((fun x y -> x && not y || not x && y) true false)
 
 This function implements an XOR operator for boolean values.
 
-Let me repeat: function literals are just values described using text. So the following basically is all the same:
+Let me repeat: function literals are just values described using text. So the following are basically all the same:
 
 ```fsharp
 123
 "Hello!"
 true
 fun x -> -x
-``` 
+```
 
-It's just values: an `int` value, a `string` value, a `bool` value. Each literal describes a value of a certain type. But what is the type of the function literal? It's `int -> int`. It's a type you define.
+They're just values: an `int` value, a `string` value, a `bool` value. Each literal describes a value of a certain type. But what is the type of the function literal? It's `int -> int`. It's a type you define.
 
-Since a function is a transformation of some input value(s) of some type into an output value of some type a function type is written like this. The transformation is signified by the `->`: what's on the left side is transformed into what's on the right side.
+Since a function is a transformation of some input value(s) of some type into an output value of some type, a function type is written like this. The transformation is signified by the `->`: what's on the left side is transformed into what's on the right side.
 
 This transformation is also visible in the function literal: The input is represented by a list of formal parameters, the output by one or more expressions. It's almost like `fun input -> output`.
 
@@ -62,15 +62,15 @@ What does that mean? It's a single function, but its type describes it as two tr
 
 Welcome to the world of Functional Programming!
 
-Remember: Functions are just values. That means, they can be combined to form new values.
+Remember: functions are just values. That means they can be combined to form new values.
 
-Here's an analogy: How is this expression evaluated?
+Here's an analogy: how is this expression evaluated?
 
 ```fsharp
 2 * (3 + 4)
 ```
 
-First `3 + 4` is calculated resulting in 7, then `2 * 7` is calculated resulting in 14. Right?
+First `3 + 4` is calculated, resulting in 7, then `2 * 7` is calculated, resulting in 14. Right?
 
 ```fsharp
 1. 2 * (3 + 4)
@@ -96,9 +96,9 @@ If you apply the "parentheses first" rule, then what's the sequence of calculati
 3. 5
 ```
 
-A function is evaluated by replacing occurrences of formal parameters with actual parameter values. If all occurrences have been replaced, the expressions get executed to produce the result. As long as there are values missing, though, an intermediate result is returned - which is a function. That's what step 2. is showing. The `2` provided in step 1. is used, but the second parameter is missing. The initial function requiring two parameters is transformed into a function requiring just one.
+A function is evaluated by replacing occurrences of formal parameters with actual arguments. If all occurrences have been replaced, the expressions get executed to produce the result. As long as there are values missing, though, an intermediate result is returned – which is a function. That's what step 2 is showing. The `2` provided in step 1 is used, but the second argument is missing. The initial function requiring two arguments is transformed into a function requiring just one.
 
-Here's sequence of evaluation of the mathematical expression showing the types involved:
+Here's the sequence of evaluation of the mathematical expression, showing the types involved:
 
 ```fsharp
 2 * (3 + 4):
@@ -122,6 +122,6 @@ Partial application is the reason for a function type like `int -> int -> int`. 
 
 ***
 
-Yeah, function literals and partial application can be a bit mind bending. But then... this is very powerful stuff. You'll come to like it. And then you'll come to miss it, once you return to a single-paradigm procedural or object-oriented language.
+Yeah, function literals and partial application can be a bit mind-bending. But then... this is very powerful stuff. You'll come to like it. And then you'll come to miss it, once you return to a single-paradigm procedural or object-oriented language.
 
-Tomorrow will be easier. Promised.
+Tomorrow will be easier. Promise.

--- a/week01/day04/README.md
+++ b/week01/day04/README.md
@@ -1,4 +1,4 @@
-# Day #4 - Naming values
+# Day #4 – Naming values
 Today is an important day. You'll learn to gain control over your F# code. Because you can control whatever you know the name of. At least that's what fairy tales and lores of magic tell us; remember [Rumpelstiltskin](http://www.eastoftheweb.com/short-stories/UBooks/Rum.shtml)? ;-)
 
 Today we'll start naming things in F# programs. These are just values without a name:
@@ -17,9 +17,9 @@ You can combine them
 (fun x y -> x + y) 41 1
 ```
 
-but if you needed a value more than once you'd have to repeat it. That's against the venerable DRY (Don't Repeat Yourself) principle.
+but if you needed a value more than once, you'd have to repeat it. That's against the venerable DRY (Don't Repeat Yourself) principle.
 
-So why not give names to values to be able to refer to them in a symbolic manner? This is done with so called _let bindings_.
+So why not give names to values, to be able to refer to them in a symbolic manner? This is done with so called _let bindings_.
 
 ```fsharp
 let answer = 42
@@ -27,11 +27,11 @@ let greeting = "Hello!"
 let add = fun x y -> x + y
 ```
 
-With _let_ you bind a name to a value. It's like a label you stick on it.
+With _let_, you bind a name to a value. It's like a label you stick on it.
 
-But it's not a variable definition like you might think! Names are just that: names. They are not bins to stuff value in and later replace the value with a different one.
+But it's not a variable definition like you might think! Names are just that: names. They are not bins to stuff a value in and later replace the value with a different one.
 
-It's not so much you assign a value to a name; rather it's assigning a name to a value. And once you did that you can use the name instead of the value:
+It's not so much that you assign a value to a name; rather it's assigning a name to a value. And once you've done that, you can use the name instead of the value:
 
 ```fsharp
 let greeting = "Hello"
@@ -45,23 +45,23 @@ printfn "the answer: %d" (add almostTheAnswer 1)
 
 Names make it so much easier to use all those values swirling around in your programs. They are like handles attached to the data. And they add meaning.
 
-By giving a name to a value like this
+By giving a name to a value, like this
 
 ```fsharp
 let answer = 42
 let calculate_volume = fun x y z -> x * y * z
 ```
 
-you inform the reader about your intention. No need to become an "archaeologist" and ask yourself "What could 42 possibly mean?", "What is fun x y z -> x * y * z for?" Instead the reader just looks at the name and knows right away. Hopefully ;-) If it's an [intention revealing name](http://c2.com/cgi/wiki?IntentionRevealingNames) that is.
+you inform the reader about your intention. No need to become an "archaeologist" and ask yourself "What could 42 possibly mean?", "What is fun x y z -> x * y * z for?" Instead, the reader just looks at the name and knows right away. Hopefully ;-). If it's an [intention-revealing name](http://c2.com/cgi/wiki?IntentionRevealingNames) that is.
 
-From this it should be obvious that a name is singular. It denotes only a single value. You cannot change what a name is referring to. A let binding is immutable.
+From this, it should be obvious that a name is singular. It denotes only a single value. You cannot change what a name is referring to. A let binding is immutable.
 
 ```fsharp
 let a = 41
 let a = 42 // does not compile!
 ```
 
-To make intention revelation even easier F# gives you quite some liberty in building names. In addition to the usual naming conventions (e.g. start an identifier with a letter or an underscore which can be followed by letters and digits) you can include special characters and even spaces in names. Just enclose them in two backticks:
+To make intention revelation even easier, F# gives you quite some liberty in building names. In addition to the usual naming conventions (e.g. start an identifier with a letter or an underscore which can be followed by letters and digits), you can include special characters and even spaces in names. Just enclose them in two backticks:
 
 ```fsharp
 let ``the ultimate answer!`` = 42
@@ -70,7 +70,7 @@ let ``is this the ultimate answer?`` = fun a -> a = ``the ultimate answer!``
 printfn "%b" (``is this the ultimate answer?`` 23)
 ```
 
-So far names have been given to literal values. But of course you can give them to values resulting from transformations, too.
+So far, names have been given to literal values. But of course you can give them to values resulting from transformations, too.
 
 ```fsharp
 let greeting = "Hello"
@@ -90,7 +90,7 @@ let welcome = fun name -> printfn "%s" (build_welcome_message "Hello" name)
 welcome "Maria"
 ```
 
-Names identify "things". A name thus only makes sense if the thing it should denote already exists. Likewise a name can only be used after it has been assigned to a value. That means F# requires you to always define names before you use them.
+Names identify "things". A name thus only makes sense if the thing it should denote already exists. Likewise, a name can only be used after it has been assigned to a value. That means F# requires you to always define names before you use them.
 
 ```fsharp
 let answer = almostTheAnswer + 1 // does not compile!
@@ -113,9 +113,9 @@ You don't need to put a full function literal to the right of the `=` of a let b
 
 ***
 
-Your F# code is gaining meaning. That's good. You're on your way to useful programs. Tomorrow we're going to solve our first real problem.
+Your F# code is gaining meaning. That's good. You're on your way to useful programs. Tomorrow, we're going to solve our first real problem.
 
-PS: To be precise you can re-bind names to other values, but only within functions. Re-binding does not work outside any function:
+PS: To be precise, you can re-bind names to other values, but only within functions. Re-binding does not work outside any function:
 
 ```
 let a = 41

--- a/week01/day05/README.md
+++ b/week01/day05/README.md
@@ -1,7 +1,7 @@
-# Day #5 - Simple decisions with if
-Programming is about data processing, i.e. calculating values and assigning them to variables. As you've seen, the first is true also for F#; but the latter is not really how you do things in Functional Programming languages. But don't let this worry you too much right now.
+# Day #5 – Simple decisions with if
+Programming is about data processing, i.e. calculating values and assigning them to variables. As you've seen, the first is true also for F#; but the latter is not really how you do things in functional programming languages. But don't let this worry you too much right now.
 
-As a small consolation today you'll meet an old acquaintance, a control structure like in any imperative programming language. Meet the _if_ expression:
+As a small consolation, today you'll meet an old acquaintance, a control structure like in any imperative programming language. Meet the _if_ expression:
 
 ```fsharp
 let name = "Peter"
@@ -13,33 +13,33 @@ This looks familiar, doesn't it? Even more if I add some indentation:
 ```fsharp
 let name = "Peter"
 
-if name = "Paul" then 
+if name = "Paul" then
   printfn "Hello, my friend!"
-else 
+else
   printfn "Hello, stranger!"
 ```
 
 Depending on the result of the boolean expression, the comparison, either this or that string is written to the console.
 
-But what looks like a statement in truth is still an expression. We're talking Functional Programming, so view `if` as a function taking three parameters: a boolean value to decide on, what to do on true, and what to do on false.
+But what looks like a statement in truth is still an expression. We're talking functional programming, so view `if` as a function taking three arguments: a boolean value to decide on, what to do on true, and what to do on false.
 
-The result of the `if` function then is whatever the result is of the branch that got executed. The next example will make that more clear:
+The result of the `if` function, then, is whatever the result is of the branch that got executed. The next example will make that more clear:
 
 ```fsharp
 let greeting name =
-  if name = "Paul" then 
+  if name = "Paul" then
     "Hello, my friend!"
-  else 
+  else
     "Hello, stranger!"
-    
+
 printfn "%s" (greeting "Peter")
 ```
 
-`greeting` is a function with one parameter. Its definition spans several lines. So far functions were one-liners. But if you indent the expressions making up the body of a function you can spread them out over multiple lines. Just be sure to use spaces, not tabs to indent!
+`greeting` is a function with one parameter. Its definition spans several lines. So far, functions were one-liners. But if you indent the expressions making up the body of a function, you can spread them out over multiple lines. Just be sure to use spaces, not tabs, to indent!
 
-Whatever is indented below the let binding line forms the body of it. Of course the same indentation level is required for all lines. This helps to let your code look tidy. No more quibbling about such details of code formatting. No more matching curly braces.
+Whatever is indented below the let binding line forms the body of it. Of course, the same indentation level is required for all lines. This helps to let your code look tidy. No more quibbling about such details of code formatting. No more matching curly braces.
 
-Since `if` returns a result, both the `then` and the `else` branch need to be present and deliver a value of the same type. That's why
+Since `if` returns a result, both the `then` and the `else` branches need to be present and deliver a value of the same type. That's why
 
 ```fsharp
 let div a b =
@@ -49,29 +49,29 @@ let div a b =
     "Division by zero!"
 ```
 
-does not compile. One branch returns an `int` the other a `string`.
+does not compile. One branch returns an `int`, the other a `string`.
 
 There are ways to deal with this kind of scenario. But that's for another day.
 
-Now let's tackle a real, although small problem.
+Now let's tackle a real, although small, problem.
 
 ## FizzBuzz Ver 0.5
 Do you know [code katas](http://en.wikipedia.org/wiki/Kata_(programming)), those small programming challenges to exercise coding skills like [TDD](http://en.wikipedia.org/wiki/Test-driven_development)?
 
-Here's such a kata, almost a hello-world-kata for any [coding dojo](http://codingdojo.org). It's called "FizzBuzz".
+Here's such a kata, almost a hello-world kata for any [coding dojo](http://codingdojo.org). It's called "FizzBuzz".
 
-Read the full description [here](https://app.box.com/s/kvrd51oykrob44xv2t379k98ay9ai568). It just takes two minutes.
+Read the full description [here](https://app.box.com/s/kvrd51oykrob44xv2t379k98ay9ai568). It takes just two minutes.
 
 You probably already envision a solution to this problem in your regular programming language. But how to do it in F#?
 
-To be frank, to solve the whole problem there is a puzzle piece missing. You haven't seen yet how to do iterations.
+To be frank, in order to solve the whole problem, there is a puzzle piece missing. You haven't seen yet how to do iterations.
 
-Nevertheless you can tackle the core problem. That is: Translate a single number into its "FizzBuzz value". Here's a walking skeleton for a stripped down version of the program.
+Nevertheless, you can tackle the core problem. That is: translate a single number into its "FizzBuzz value". Here's a walking skeleton for a stripped-down version of the program.
 
 ```fsharp
 let fizzbuzz_number n =
   sprintf "%d" n
-  
+
 printfn "%b" ((fizzbuzz_number 1) = "1")
 printfn "%b" ((fizzbuzz_number 3) = "Fizz")
 printfn "%b" ((fizzbuzz_number 5) = "Buzz")
@@ -82,7 +82,7 @@ printfn "%b" ((fizzbuzz_number 17) = "17")
 
 A first, all too simple function definition with a couple of poor man's automated tests.
 
-Note the `sprintf` function which prints to a string where `printf` prints to the console. It's just a placeholder for the real logic of the solution.
+Note the `sprintf` function, which prints to a string whereas `printf` prints to the console. It's just a placeholder for the real logic of the solution.
 
 But the real solution is not very complicated either:
 
@@ -100,7 +100,7 @@ let fizzbuzz_number n =
 
 It's just a couple of nested `if` expressions.
 
-Although this logic serves the purpose, it's arguably not clean, not DRY. Checking for a Fizz- and Buzz-number is done in two places.
+Although this logic serves the purpose, it's arguably not clean, not DRY. Checking for Fizz and Buzz numbers is done in two places.
 
 That can be improved by introducing functions for these checks:
 
@@ -109,7 +109,7 @@ let fizzbuzz_number n =
   let ``is fizz?`` n = n % 3 = 0
   let ``is buzz?`` n = n % 5 = 0
   let ``is fizzbuzz?`` n = (``is fizz?`` n) && (``is buzz?`` n)
-  
+
   if ``is fizzbuzz?`` n then
     "FizzBuzz"
   else if ``is fizz?`` n then
@@ -120,7 +120,7 @@ let fizzbuzz_number n =
     sprintf "%d" n
 ```
 
-Since they are of no interest to the outside, they are defined locally within the scope of `fizzbuzz_number`. A feat not possible in many other languages including C#. But a very useful language feature, because it improves encapsulation by limiting the visibility of functions.
+Since they are of no interest to the outside, they are defined locally within the scope of `fizzbuzz_number`. A feat not possible in many other languages, including C#. But a very useful language feature, because it improves encapsulation by limiting the visibility of functions.
 
 That's it. Problem solved. Or at least the first part of the problem.
 
@@ -132,7 +132,7 @@ let assert_result given expected =
     printfn "OK for %d: %s" given expected
   else
     printfn "FAILED for %d, expected %s" given expected
-  
+
 assert_result 1 "1"
 assert_result 3 "Fizz"
 assert_result 5 "Buzz"
@@ -141,8 +141,8 @@ assert_result 15 "FizzBuzz"
 assert_result 17 "17"
 ```
 
-As you see it's quite easy to come up with your own small automated test framework ;-)
+As you see, it's quite easy to come up with your own small automated test framework ;-).
 
 ***
 
-You've put F# to real use for the first time. One of the prevalent problems of computing science has been solved. Almost, at least ;-) Let's see if we can finish it tomorrow.
+You've put F# to real use for the first time. One of the prevalent problems of computing science has been solved. Almost, at least ;-). Let's see if we can finish it tomorrow.

--- a/week02/day06/README.md
+++ b/week02/day06/README.md
@@ -1,20 +1,20 @@
-# Day #6 - Recursion
+# Day #6 – Recursion
 I'm sure you're keen to finish the ["FizzBuzz" code kata](https://app.box.com/s/kvrd51oykrob44xv2t379k98ay9ai568). So let's think about how to do iterations.
 
 In C# or Java or Ruby you'd use some kind of loop to fizzbuzz all the numbers in the range from 1 to 100. Here's an example in C#:
 
 ```csharp
-for(var i=1; i<=100; i++) {
+for (var i=1; i<=100; i++) {
   var v = Fizzbuzz_number(i);
-  Console.WriteLine(v)
+  Console.WriteLine(v);
 }
 ```
 
-This can be done in F#, too. But there is a more natural way, a more function oriented way of doing it. Maybe you remember from some computer science class that any loop can be converted into a recursion - and any recursion can be converted into a loop.
+This can be done in F#, too. But there is a more natural way, a more functional-oriented way of doing it. Maybe you remember from some computer science class that any loop can be converted into a recursion – and any recursion can be converted into a loop.
 
-That's what we want to apply today: We have a looping problem, so let's solve it with recursion.
+That's what we want to apply today: we have a looping problem, so let's solve it with recursion.
 
-You already know how to call a function. So you can do recursion, too. Almost at least. Here's the canonical recursion example: a factorial function. But it won't work, yet.
+You already know how to call a function, so you can do recursion, too. Almost, at least. Here's the canonical recursion example: a factorial function. But it won't work, yet.
 
 ```fsharp
 let factorial n =
@@ -24,7 +24,7 @@ let factorial n =
     n * (factorial (n-1)) // fails to compile!
 ```
 
-The reason: You need to mark functions to be called recursively as such with `rec` right after the `let` keyword.
+The reason: you need to mark functions to be called recursively as such with `rec` right after the `let` keyword.
 
 ```fsharp
 let rec factorial n =
@@ -38,9 +38,9 @@ printfn "%d" (factorial 6)
 
 This now works and prints 720. Great!
 
-But how can this help with iteration over a range of numbers? Well, isn't this a problem, where you do one thing for a value at the head of a list, remove the value from the list - and then repeat this with the remaining elements in the list?
+But how can this help with iteration over a range of numbers? Well, isn't this a problem where you do one thing for a value at the head of a list, remove the value from the list and then repeat this with the remaining elements in the list?
 
-The list in this case is defined as a range, e.g. from 1 until 100. 1 is the head of the list. So something is done with 1, then 1 is removed leaving a list from 2 until 100. Then the same is done with this remaining list - until the list is empty.
+The list in this case is defined as a range, e.g. from 1 to 100. 1 is the head of the list. So something is done with 1, then 1 is removed, leaving a list from 2 to 100. Then the same is done with this remaining list, until the list is empty.
 
 That probably sounds more complicated than it is, though. Better to see it in code. Here is a simple iteration function:
 
@@ -51,7 +51,7 @@ let rec iter from until =
     iter (from + 1) until
   else
     printfn "%d" from
-    
+
 iter 0 5
 ```
 
@@ -59,7 +59,7 @@ Note that abortion of the recursion again is not possible with just a simple `if
 
 You see the pattern? Recursion is bounded by a condition. If the condition is met, recursion is aborted, otherwise the function calls itself. In each case, whatever should be done with the current value is done.
 
-So why not generalize this pattern? Iterations are all the same whether for "FizzBuzz" or other problems like calculating the squares in a range.
+So why not generalize this pattern? Iterations are all the same whether for "FizzBuzz" or other problems, like calculating the squares in a range.
 
 Here is a general iteration function for integer ranges:
 
@@ -70,24 +70,24 @@ let rec iter f from until =
     iter f (from + 1) until
   else
     f from
-    
+
 iter (printfn "%d") 0 5
 ```
 
-What should be done for each number is passed in as a function! That's true Functional Programming. Remember: functions are values. They can be used like integer or strings. So why not have formal parameters expecting a function to be passed in?
+What should be done for each number is passed in as a function! That's true functional programming. Remember: functions are values. They can be used like integer or strings. So why not have formal parameters expecting a function to be passed in?
 
 Parameters `from` and `until` are used like numbers, so numbers are given when calling `iter`. But `f` is used like a function, so a function is given when calling `iter`.
 
-`(printfn "%d")` is a partial application of `printfn`. That's why it's ok to leave out any value to print when using it as a parameter. The missing value later is passed in when `f` (as a placeholder for the value of `printfn "%d"`) is called within `iter`: `f from`. This results in `printfn "%d" from` being evaluated.
+`(printfn "%d")` is a partial application of `printfn`. That's why it's OK to leave out any value to print when using it as a parameter. The missing value is later passed in when `f` (as a placeholder for the value of `printfn "%d"`) is called within `iter`: `f from`. This results in `printfn "%d" from` being evaluated.
 
-Please note the above general `iter` function does not return a result, but `unit` like `printf` does. Hence you need to pass in a function to also return `unit`. That's the case in the "FizzBuzz" solution.
+Please note that the above general `iter` function does not return a result but `unit`, like `printf` does. Hence you need to pass in a function that also returns `unit`. That's the case in the "FizzBuzz" solution.
 
-How to do iterations with functions returning results of other types is the topic for another day.
+How to do iterations with functions returning results of other types is a topic for another day.
 
 ## FizzBuzz Ver 0.9
-With such an iteration function in hand it's easy to finish the "FizzBuzz" solution.
+With such an iteration function in hand, it's easy to finish the "FizzBuzz" solution.
 
-The problem isn't iteration any more. That's solved. Rather the question is: What should be done for each number in the range?
+The problem isn't iteration any more. That's solved. Rather, the question is: what should be done for each number in the range?
 
 It should be converted and printed.
 
@@ -98,10 +98,10 @@ let fizzbuzz from until =
   let convert_number i =
     let v = fizzbuzz_number i
     printfn "%s" v
-  
+
   iter convert_number from until
-    
-    
+
+
 fizzbuzz 1 100
 ```
 
@@ -109,4 +109,4 @@ See [here](src/fizzbuzz.fs) for the full source code.
 
 ***
 
-Recursion and functions as parameters: What a day! That's two powerful techniques of Functional Programming. Still, though, it seems iteration over a range of numbers should be easier than that, right? More on that tomorrow.
+Recursion and functions as parameters: What a day! That's two powerful techniques of functional programming. Still, though, it seems iteration over a range of numbers should be easier than that, right? More on that tomorrow.

--- a/week02/day07/README.md
+++ b/week02/day07/README.md
@@ -1,12 +1,12 @@
-# Day #7 - Lists
-As you saw yesterday it's possible to iterate over a collection of values using recursion. That's nice to know - but in many cases it's overkill. Why not write down the values directly as a collection, at least as long as it's not too many?
+# Day #7 – Lists
+As you saw yesterday, it's possible to iterate over a collection of values using recursion. That's nice to know – but in many cases it's overkill. Why not write down the values directly as a collection, at least as long as it's not too many?
 
 This is what list literals are about. A list is a non-primitive type; it's a collection of values of the same type listed in a certain order. And it has its own literal syntax: write the list elements separated by ";" between square brackets. Some examples:
 
 ```fsharp
 let positive = [1; 2; 3]
 let abc = ["a"; "b"; "c"]
-let ops = [(fun x y -> x + y); (fun a b -> a * b); (-) ]
+let ops = [(fun x y -> x + y); (fun a b -> a * b); (-)]
 let nested = [[1; 2; 3]; [1; 4; 9]]
 ```
 
@@ -14,21 +14,21 @@ You see, any value can become an element of a list, even functions and lists the
 
 An empty list is denoted by `[]`.
 
-To access a specific list item you can use the `Item()` member function:
+To access a specific list item you can use the `Item(int)` member function:
 
 ```fsharp
 printfn "%s" (abc.Item(1))
 printfn "%d" (ops.Item(0) 2 3)
 ```
 
-Or you can do it a bit more array-like by suffixing the list name with `.[index]`:
+Or you can do it a bit more array-like, by suffixing the list name with `.[index]`:
 
 ```fsharp
 printfn "%s" abc.[1]
 printfn "%d" (ops.[0] 2 3)
 ```
 
-Don't be fooled, though. F# lists are not your usual lists you know from C# for example. F# lists are immutable! You cannot change their content. There is no assignment to an item, there is no deletion of items etc.
+Don't be fooled, though. F# lists are not your usual lists you know from C#, for example. F# lists are immutable! You cannot change their content. There is no assignment to an item, there is no deletion of items etc.
 
 They are not even optimized for random access via an index. So even though you can access individual elements like above, you usually want to find a different way.
 
@@ -51,16 +51,16 @@ let natural = [-3; -2; -1] @ positiveAnd0
 let powers = [1; 10; 100] @ [1; 2; 4; 8] @ [1; 16; 256; 4096]
 ```
 
-Note that lists are not sets. That means the value 1 occurrs three times in list `powers`. You can check this by printing the list using `%A` as the placeholder:
+Note that lists are not sets. That means that the value 1 occurs three times in list `powers`. You can check this by printing the list using `%A` as the placeholder:
 
 ```fsharp
 printfn "%A" powers
 ```
 
-See, how nicely F# formats the output of this non-primitive type?
+See how nicely F# formats the output of this non-primitive type?
 
 ## Iteration
-Now you have lists. But how to work with them, how to work with their elements? Yesterday's `iter` function was able to generate the next element by doing a calculation. But with arbitrary and existing lists, how can you move through their items?
+Now you have lists. But how do you work with them, how do you work with their elements? Yesterday's `iter` function was able to generate the next element by doing a calculation. But with arbitrary and existing lists, how can you move through their items?
 
 Lists provide two additional properties: `Head` and `Tail`.
 
@@ -68,7 +68,7 @@ Lists provide two additional properties: `Head` and `Tail`.
 
 ```fsharp
 printfn "%d" ([1; 2; 3].Head)
-``` 
+```
 
 `Tail` returns all items after the first as a list. This prints `[2; 3]`:
 
@@ -76,7 +76,7 @@ printfn "%d" ([1; 2; 3].Head)
 printfn "%A" ([1; 2; 3]].Tail)
 ```
 
-With these properties in hand you can create, for example, a function `map` to apply some function to all elements of a list:
+With these properties in hand you can create, for example, a `map` function to apply some function to all elements of a list:
 
 ```fsharp
 let rec map f source =
@@ -87,7 +87,7 @@ let rec map f source =
 
 `map` applies the function `f` to the head of the list `source` passed in, thus creating a new head for the resulting list. The tail of the resulting list is then created by calling itself recursively with the tail of the `source` list.
 
-Only if `map` is called with an empty list it immediately returns an empty list.
+If `map` is called with an empty list, it immediately returns an empty list.
 
 ```fsharp
 map (fun x -> x * x) positive
@@ -95,7 +95,7 @@ map (fun x -> x * x) positive
 
 The list of squared values thus does not exist explicitly, but only on the stack while the recursion goes on towards the end of the original `source` list.
 
-This is how working on lists in F# typically looks like - if you need to implement it yourself. Fortunately, though, you don't have to do that all the time. F# comes with quite an assortment of built in list functions. They are available from the `List` module like this:
+This is how working on lists in F# typically looks like – if you need to implement it yourself. Fortunately, though, you don't have to do that all the time. F# comes with quite an assortment of built-in list functions. They are available from the `List` module:
 
 ```fsharp
 List.map (fun x -> x * x) [1; 2; 3]
@@ -104,19 +104,19 @@ List.fold (fun s x -> s + x) 0 [1; 2; 3]
 List.iter (fun x -> printfn "%d" x) [1; 2; 3]
 ```
 
-`List.map`, `List.filter`, and `List.fold` are quite useful in many situations as well as easy to understand - especially if you're familiar with .NET Linq.
+`List.map`, `List.filter`, and `List.fold` are quite useful in many situations as well as easy to understand, especially if you're familiar with .NET LINQ.
 
-* `List.map` corresponds to Linq `Select()`. The above example thus results in `[1; 4; 9]`.
-* `List.filter` corresponds to Linq `Where()`. The above example returns `[2]`.
-* `List.fold` corresponds to Linq `Aggregate()`. The above example returns `6` as the sum of all elements.
-* `List.iter` corresponds to Linq `ForEach()` for `IList<T>`. The above example prints the elements of the list.
+* `List.map` corresponds to LINQ `Select()`. The above example thus results in `[1; 4; 9]`.
+* `List.filter` corresponds to LINQ `Where()`. The above example returns `[2]`.
+* `List.fold` corresponds to LINQ `Aggregate()`. The above example returns `6` as the sum of all elements.
+* `List.iter` corresponds to LINQ `ForEach()` for `IList<T>`. The above example prints the elements of the list.
 
-The the [F# documentation](https://msdn.microsoft.com/en-us/library/dd233224.aspx) for more of these functions.
+See the [F# documentation](https://msdn.microsoft.com/en-us/library/dd233224.aspx) for more of these functions.
 
-Interestingly the `List` module also sports `List.head` and `List.tail`. So which should you use? The more F# like `List.tail abc` or the more object-oriented `abc.Tail`. The recommendation is: go the F# way! It makes it easier for the compiler to weave its type inference magic.
+Interestingly, the `List` module also sports `List.head` and `List.tail`. So which should you use? The more functional `List.tail abc` or the more object-oriented `abc.Tail`? The recommendation is: go the functional way! It makes it easier for the compiler to weave its type inference magic.
 
 ## Filling lists with a range
-So far lists were initialized with a static literal. That's ok for small lists. But what if a list was to contain dozens, even hundreds of items?
+So far, lists were initialized with a static literal. That's OK for small lists. But what if a list was to contain dozens, even hundreds of items?
 
 If those items belong to a range then it's easy to fill the list. Just apply the range operator:
 
@@ -125,9 +125,9 @@ let positive = [1..3]
 let abc = ['a'..'c']
 ```
 
-In list brackets write the lower bound of the range followed by `..` and then the upper bound of the range. F# will create all items in that range for you. It can accomplish this feat for numbers and characters.
+In list brackets, write the lower bound of the range followed by `..` and then the upper bound of the range. F# will create all items in that range for you. It can accomplish this feat for numbers and characters.
 
-And if you like it can even apply an increment you supply:
+And if you like, it can even apply an increment you supply:
 
 ```fsharp
 let even = [2..2..10]
@@ -138,11 +138,11 @@ results in `[2; 4; 6; 8; 10]`.
 ## FizzBuzz Ver 1.0
 Back to the "FizzBuzz" kata. How can lists help to make the code even simpler?
 
-First the self-defined function `iter` is not necessary anymore. Instead `List.iter` should be used.
+First of all, the self-defined function `iter` is not necessary anymore. Instead `List.iter` should be used.
 
-Then the range of numbers does not need to be produced algorithmically. Instead a list auto-filled with the numbers can be used.
+Furthermore, the range of numbers does not need to be produced algorithmically. Instead, a list auto-filled with the numbers can be used.
 
-Finally it seems a small refactoring is in order. Why not make number checking local to the `fizzbuzz` function?
+Finally, it seems a small refactoring is in order. Why not make number checking local to the `fizzbuzz` function?
 
 ```fsharp
 let fizzbuzz numbers =
@@ -150,7 +150,7 @@ let fizzbuzz numbers =
     let ``is fizz?`` n = n % 3 = 0
     let ``is buzz?`` n = n % 5 = 0
     let ``is fizzbuzz?`` n = (``is fizz?`` n) && (``is buzz?`` n)
-      
+
     if ``is fizzbuzz?`` n then
       "FizzBuzz"
     else if ``is fizz?`` n then
@@ -163,14 +163,13 @@ let fizzbuzz numbers =
   let convert_number i =
     let v = fizzbuzz_number i
     printfn "%s" v
-  
+
   List.iter convert_number numbers
-    
-    
+
 fizzbuzz [1..20]
 ```
 
-Speaking of refactoring... As it seems `fizzbuzz` has two responsibilities: mapping numbers and printing the resulting list. The code would be cleaner if these aspects were separated. Maybe like this:
+Speaking of refactoring... As it is, `fizzbuzz` has two responsibilities: mapping numbers and printing the resulting list. The code would be cleaner if these aspects were separated. Maybe like this:
 
 ```fsharp
 let fizzbuzz numbers =
@@ -178,7 +177,7 @@ let fizzbuzz numbers =
     let ``is fizz?`` n = n % 3 = 0
     let ``is buzz?`` n = n % 5 = 0
     let ``is fizzbuzz?`` n = (``is fizz?`` n) && (``is buzz?`` n)
-      
+
     if ``is fizzbuzz?`` n then
       "FizzBuzz"
     else if ``is fizz?`` n then
@@ -187,9 +186,9 @@ let fizzbuzz numbers =
       "Buzz"
     else
       sprintf "%d" n  
-  
+
   List.map fizzbuzz_number numbers
-    
+
 let converted = fizzbuzz [1..20]
 List.iter (printfn "%s") converted
 ```

--- a/week02/day08/README.md
+++ b/week02/day08/README.md
@@ -1,18 +1,18 @@
-# Day #8 - Arrays
+# Day #8 – Arrays
 Learning a language is easier when you know why, when you have a goal. That's why today's lesson starts with a kata. First the problem, then an introduction to helpful language features.
 
 Please have a look at the [requirements document](https://app.box.com/s/z07b8gr6e1ngvb3cg7ps78zy2ddi3vx1). The requested solution is still small, but there is enough to learn in it for a couple of days.
 
 Let's start with a list of features that need to be implemented. From that you can get an idea what's missing in your F# toolbox.
 
-* A program, not just a function needs to be written. That means, at least in the end you need to use an IDE like Visual Studio or Xamarin Studio to compile the code into a standalone executable for your operating system.
+* A program, not just a function needs to be written. That means that, at least in the end, you need to use an IDE like Visual Studio or Xamarin Studio to compile the code into a standalone executable for your operating system.
 * The program needs access to the command line to read the number to convert.
 * The program needs to write the conversion result to standard output.
 * A roman number needs to be converted to an arabic number.
 * An arabic number needs to be converted to a roman number.
 * A decision must be made which conversion to use.
 
-This all of course is easy in your "mother tongue" programming language. But with F# this is different. You don't even know how to get F# code started from the command line - at least if you've followed along using one of the online REPL environments like [tryfsharp.org](http://www.tryfsharp.org/Create).
+This is all of course easy in your "mother tongue" programming language. But with F# this is different. You don't even know how to get F# code started from the command line – at least if you've followed along using one of the online REPL environments like [tryfsharp.org](http://www.tryfsharp.org/Create).
 
 ## Defining an entry point
 Programs need an entry point, i.e. the operating system has to be pointed to where to start running a program's code. For F# this means a function needs to be marked as the root of all execution.
@@ -21,14 +21,14 @@ That's done with a .NET attribute like this:
 
 ```fsharp
 [<EntryPoint>]
-let main argv = 
+let main argv =
     printfn "Hello, World!"
     0
 ```
 
 Any function can be marked as the entry point; use the attribute `[<EntryPoint>]` to do that. (Note the difference in syntax between F# and C#: attributes are enclosed in `[< >]` in F#.)
 
-The entry point function then needs to be of type `string[] -> int`. The command line parameters are passed in as a `string` array. And it returns an `int` exit code; that's why `0` is on the last line of the function's body. Remember: `printf` does not return a real value, just `unit`.
+The entry point function then needs to be of type `string[] -> int`. The command line parameters are passed in as a `string` array, and it returns an `int` exit code; that's why `0` is on the last line of the function's body. Remember: `printf` does not return a real value, just `unit`.
 
 In C# this looks a bit more elaborate: a class is needed, the method must be made static, curly braces delineate the scope of the function, there is no "native" function to write to standard output; it can but need not return an exit code.
 
@@ -42,24 +42,24 @@ class Program {
 ```
 
 ## Arrays
-The command line parameters are passed into the entry point function as an array. So far you have seen how lists work. But arrays?
+The command line arguments are passed into the entry point function as an array. So far you have seen how lists work. But arrays?
 
-They are similar to lists as you can see here:
+They are similar to lists, as you can see here:
 
 ```fsharp
-let numberlist = [1;2;3]
-let numberarray = [|1;2;3|]
+let numberList = [1;2;3]
+let numberArray = [|1;2;3|]
 
-let nestedlists = [[1;2]; [3;4;5]]
-let nestedarrays = [| [|1;2|]; [|3;4;5|] |]
+let nestedLists = [[1;2]; [3;4;5]]
+let nestedArrays = [| [|1;2|]; [|3;4;5|] |]
 
 let square x = x * x
 
-List.map square numberlist
-Array.map square numberarray
+List.map square numberList
+Array.map square numberArray
 
-printfn "%d" numberlist.[0]
-printfn "%d" numberarray.[0]
+printfn "%d" numberList.[0]
+printfn "%d" numberArray.[0]
 ```
 
 Array literals are denoted by `[|` and `|]`, though. But to get at an array element you use `.[index]` like for lists.
@@ -71,36 +71,36 @@ Lists are immutable and of dynamic size. But arrays are mutable and of fixed siz
 Here's how you change an element of an array:
 
 ```fsharp
-numberarray.[0] <- 99
+numberArray.[0] <- 99
 ```
 
 Use either the `<-` operator or the `set` function:
 
 ```fsharp
-Array.set numberarray 0 99
+Array.set numberArray 0 99
 ```
 
-The fixed size nature of arrays becomes apparent when you create them. You can use a literal like above or the `create` function:
+The fixed-size nature of arrays becomes apparent when you create them. You can use a literal like above, or the `create` function:
 
 ```fsharp
-let numberarray = Array.create 3 0
-numberarray.[0] <- 1
-numberarray.[1] <- 2
-numberarray.[2] <- 3
+let numberArray = Array.create 3 0
+numberArray.[0] <- 1
+numberArray.[1] <- 2
+numberArray.[2] <- 3
 ```
 
 Lists are meant to grow. That's why there are operators like `::` and `@` and even more F# features tailored to list manipulation.
 
-Arrays are not meant to grow. So there are no special language features for that. Nevertheless you can append to or "contract" arrays - but this always creates new arrays.
+Arrays are not meant to grow. So there are no special language features for that. Nevertheless, you can append to or "contract" arrays – but this always creates new arrays.
 
 ```fsharp
 let numbers = Array.append [|1;2|] [|3;4;5|]
-let middlepart = Array.sub numbers 1 3
+let middlePart = Array.sub numbers 1 3
 ```
 
 `Array.sub` extracts a number of array elements starting at a specified index.
 
-Alternatively you can use index ranges to extract stretches of array elements:
+Alternatively, you can use index ranges to extract stretches of array elements:
 
 ```fsharp
 numbers.[1..3] // like Array.sub numbers 1 3
@@ -110,11 +110,11 @@ numbers.[..3] // only up to index 3
 
 How to choose between arrays and lists? Let your default be lists. They are more flexible. But if you need more efficiency or mutability or interoperability with the CLR/BCL, then choose arrays.
 
-And in case you can't decide... you can start with one and later switch to the other ;-)
+And in case you can't decide... you can start with one and later switch to the other ;-).
 
 ```fsharp
-let numberlist = Array.toList [|1;2;3|]  
-let numberarray = List.toArray [1;2;3]
+let numberList = Array.toList [|1;2;3|]  
+let numberArray = List.toArray [1;2;3]
 ```
 
 Read more about arrays in the [language documentation](https://msdn.microsoft.com/en-us/library/dd233214.aspx) if you like. There are quite some features to be discovered.
@@ -132,12 +132,12 @@ You find the full source in the [repo](src/convertroman/Program.fs).
 
 ***
 
-Three of six features implemented. Not bad for a short day of F#. But how to decide between the number systems? That's the topic for tomorrow.
+Three out of six features implemented. Not bad for a short day of F#. But how to decide between the number systems? That's the topic for tomorrow.
 
 ***
 
-PS: Just in case you want to know: You don't really need an IDE for this kind of project. You can stick to a text editor like [Sublime](http://www.sublimetext.com) and use _fsharpc_, the F# command line compiler.
+PS. Just in case you want to know: you don't really need an IDE for this kind of project. You can stick to a text editor like [Sublime](http://www.sublimetext.com) and use _fsharpc_, the F# command line compiler.
 
 ![](images/w02d08b.png)
 
-The compiler comes with Mono like the C# compiler.
+The compiler comes with Mono, like the C# compiler.

--- a/week02/day09/README.md
+++ b/week02/day09/README.md
@@ -1,4 +1,4 @@
-# Day #9 - Tuples
+# Day #9 – Tuples
 Today we'll focus on just one feature of the ["Convert roman" kata](https://app.box.com/s/z07b8gr6e1ngvb3cg7ps78zy2ddi3vx1): determine the type of number to be converted. Is it a roman number or an arabic one?
 
 The function to accomplish this is
@@ -9,12 +9,12 @@ let is_roman_number n = // ...
 
 with a type of `string -> bool`.
 
-But how to analyse the string? There are two ways to do that:
+But how to analyze the string? There are two ways to do that:
 
 * Try to convert the string into an integer. If it succeeds, then it's an arabic number, otherwise assume it to be a roman number.
 * Check the characters of the string to be in the set of valid roman digits (I, V, X, L, C, D, M).
 
-Both can easily be done with functions from the .NET BCL: `TryParse()` and `Regex.Match()`.
+Both can easily be done with functions from the .NET BCL: `Int32.TryParse()` and `Regex.Match()`.
 
 ## Namespaces
 Both function are static and can readily be used from F#:
@@ -35,7 +35,7 @@ let m = Regex.Match("XLII", "^[IVXLCDM]*$")
 ```
 
 ## Tuples
-You might have noticed unlike F# functions the BCL functions need parentheses around their parameters. That's because, well, they are not F# functions, but prefab functions from an object-oriented .NET library.
+You might have noticed that unlike F# functions, the BCL functions need parentheses around their parameters. That's because, well, they are not F# functions, but prefab functions from an object-oriented .NET library.
 
 Or to be precise: they need parentheses if you pass in more than one parameter.
 
@@ -46,7 +46,7 @@ System.Console.WriteLine ("Hello, {0}", "Peter")
 
 C# does not sport partial function application. And the BCL libraries have to be language agnostic. That's why from the F# point of view all BCL functions take one parameter: a tuple.
 
-A tuple is two or more comma separated values bound together by parentheses:
+A tuple is two or more comma-separated values bound together by parentheses:
 
 ```fsharp
 let p = ("Peter", 34)
@@ -64,9 +64,9 @@ Read for example: all possible values of `string` times all possible values of `
 
 Lists and arrays are structured values, too. But their unnamed elements all need to be of the same type. And lists have no fixed length.
 
-For now think of tuples as some kind of poor man's records ;-) But look how cheap they are. No type definition needed, no need to use a special type like `Tuple<T0, T1, ...>` in C#.
+For now think of tuples as some kind of poor man's records ;-). But look how cheap they are. No type definition needed, no need to use a special type like `Tuple<T0, T1, ...>` in C#.
 
-Whereas elements in lists and arrays can be accessed via an index, that's not possible for tuples. Instead you need to deconstruct a tuple using a let binding to get at its fields:
+Whereas elements in lists and arrays can be accessed via an index, that's not possible for tuples. Instead, you need to deconstruct a tuple using a let binding to get at its fields:
 
 ```fsharp
 let name, age = p
@@ -84,7 +84,7 @@ let intdiv a b =
   let quotient = a / b
   let remainder = a % b
   quotient, remainder
-  
+
 let (q, r) = intdiv 14 4
 printfn "%d, %d" q r
 ```
@@ -100,7 +100,7 @@ let (success, value) = Int32.TryParse("42")
 printfn "%b, %d" success value
 ```
 
-Also tuples are the way to go when you want to circumvent partial application. Think of a function on a 2D point. For such a function you'd want to force its clients to always provide x and y together when calling it. That's accomplished with a tuple:
+Also, tuples are the way to go when you want to circumvent partial application. Think of a function on a 2D point. For such a function you'd want to force its clients to always provide x and y together when calling it. That's accomplished with a tuple:
 
 ```fsharp
 let translate (x, y) d =
@@ -109,7 +109,7 @@ let translate (x, y) d =
 let a = translate (2, 5) 3
 ```
 
-A partial application of `translate` is still possible - but not with regard to `x` and `y`. Either both are provided or none of them.
+A partial application of `translate` is still possible – but not with regard to `x` and `y`. Either both are provided or none of them.
 
 Back to BCL functions. They require you to pass all parameters at once using a tuple, e.g.
 
@@ -132,10 +132,10 @@ let m = Regex.Match p // does not compile!
 
 Bummer :-(
 
-But anyway... Calls to BCL or C# functions in an assembly are straightforward to do. Which is also true for accessing properties of objects returned from such functions. See the `Match` object returned from the `Regex.Match()` function: To check if a pattern match occurred just query the `Success` property.
+But anyway... Calls to BCL or C# functions in an assembly are straightforward to do, which is also true for accessing properties of objects returned from such functions. See the `Match` object returned from the `Regex.Match()` function: To check if a pattern match occurred just query the `Success` property.
 
 ## Refining the solution
-With tuples today's task - to implement the function for checking the type of number passed to the conversion program - becomes quite easy. There are two solutions to choose from.
+With tuples being today's task, implementing the function for checking the type of number passed to the conversion program becomes quite easy. There are two solutions to choose from.
 
 ```fsharp
 open System
@@ -161,9 +161,9 @@ See [here](src/convertroman/Program.fs) for the current source files of the proj
 
 ***
 
-Four of six features implemented! Great! And being able to tap into the power of the .NET BCL sure will turn out to be very useful in the future as well. Maybe already tomorrow...
+Four out of six features implemented! Great! And being able to tap into the power of the .NET BCL sure will turn out to be very useful in the future as well. Maybe already tomorrow...
 
 ### Read more
-* Scott Wlaschin, [Tuples - Multiplying types together](http://fsharpforfunandprofit.com/posts/tuples/)
+* Scott Wlaschin, [Tuples – Multiplying types together](http://fsharpforfunandprofit.com/posts/tuples/)
 * Wikibooks, [F Sharp Programming / Tuples and Records](https://en.wikibooks.org/wiki/F_Sharp_Programming/Tuples_and_Records)
 * Microsoft, [Tuples (F#)](https://msdn.microsoft.com/de-de/library/dd233200.aspx)

--- a/week02/day10/README.md
+++ b/week02/day10/README.md
@@ -1,4 +1,4 @@
-# Day #10 - Operator definition and type constraints
+# Day #10 – Operator definition and type constraints
 The next feature of the "Convert roman" kata is to actually do a conversion: convert from a roman number to an arabic one, e.g. XLII to 42.
 
 The signature for that function is simple:
@@ -12,16 +12,16 @@ But how to do this? Do you already know enough of F# to implement a solution?
 Time for some thinking...
 
 ## Solution design
-Before you can write any code you not only need to understand the problem, but also have an idea of how your solution should look like. You can call that a plan or design.
+Before you can write any code, you not only need to understand the problem, but also have an idea of what your solution should look like. You can call that a plan or design.
 
-A design is a solution on paper so to speak. And your F# code then is the solution with all its details. The design is more abstract, more coarse grained.
+A design is a solution on paper, so to speak, and your F# code is the solution with all its details. The design is more abstract, more coarse grained.
 
 Finding the solution design is the most creative part of programming. Translating it into code is comparatively straightforward most of the time.
 
 So how does converting a roman number into an arabic one work? What are the necessary steps in this transformation process?
 
-* Roman numbers (e.g. VI) consist of roman digits each represented by a single character (e.g. V) and corresponding to a decimal value (e.g. 5). It seems obvious that a roman number first should be split into its digits which then are mapped to their values.
-* The values making up a roman number then can be summed up to calculate the arabic number result.
+* Roman numbers (e.g. VI) consist of roman digits, each represented by a single character (e.g. V) that corresponds to a decimal value (e.g. 5). It seems obvious that a roman number first should be split into its digits, which then are mapped to their values.
+* The values making up a roman number can then be summed up to calculate the arabic number result.
 * Except for those pesky smaller values in front of larger ones, e.g. the I in IV or the X in XC. They have to be negated first to get them subtracted instead of added.
 
 These are distinct aspects or features of the solution. They should be encoded in their own functions with [focused responsibilities](http://geekswithblogs.net/theArchitectsNapkin/archive/2015/04/25/the-single-responsibility-principle-under-the-microscope.aspx). Let the SRP rule! :-)
@@ -29,15 +29,15 @@ These are distinct aspects or features of the solution. They should be encoded i
 The outline of the solution then would look like this:
 
 ```fsharp
-let map_digits_to_values roman = 
+let map_digits_to_values roman =
   // "XIV" => [10; 1; 5]
-  
+
 let negate_smaller_values values =
   // [10; 1; 5] => [10; -1; 5]
 
 let values = map_digits_to_values roman
-let negvalues = negate_smaller_values values
-List.sum negvalues
+let negValues = negate_smaller_values values
+List.sum negValues
 
 ```
 
@@ -47,7 +47,7 @@ This looks straightforward to implement. But F# can do better than that.
 The lines integrating the feature functions into a whole are pretty noisy. You could even say they violate the DRY principle: They repeat on the left side of the binding part of the right side, e.g.
 
 ```fsharp
-let negvalues = negate_smaller_values values
+let negValues = negate_smaller_values values
 ```
 
 It's negated values that get created by a function that negates values. The meaning of what's happening is not focused on either side. That way the binding could become inconsistent by changing only a part of it, e.g.
@@ -81,7 +81,7 @@ The pipe operator is called like this because with it it's easy to describe proc
 let even_only n = n % 2 = 0
 let square x = x * x
 
-[1; 2; 3; 4; 5] |> List.filter even_only 
+[1; 2; 3; 4; 5] |> List.filter even_only
                 |> List.map square
                 |> List.iter (printfn "%d")
 ```
@@ -109,7 +109,7 @@ let (|>) x f = f x
 
 It's that simple.
 
-Operators are functions like any other - but their identifiers may only consist of the following special characters: `!$%&*+-./<=>?@^|~`
+Operators are functions like any other – but their identifiers may only consist of the following special characters: `!$%&*+-./<=>?@^|~`
 
 And because these functions are operators you can use them infix like you're used to from + or /.
 
@@ -134,10 +134,10 @@ let (+) a b = a @ b
 [1; 2] + [3; 4]
 ```
 
-Just remember: The types of both parameters of infix operators need to be the same!
+Just remember: the types of both parameters of infix operators need to be the same!
 
 ## Type constraints
-As useful as the pipe operator is and as interesting operator overloading looks, it's not required for the solution. You could do without - your code would just be harder to read.
+As useful as the pipe operator is and as interesting operator overloading looks, it's not required for the solution. You could do without – your code would just be harder to read.
 
 So let's zoom into one of the features and figure out how to implement it:
 
@@ -147,8 +147,8 @@ let map_digits_to_values roman = // ...
 
 There are two sub-features to it:
 
-* converting the roman number string into a character array, and
-* mapping each character aka roman digit to its value
+* Converting the roman number string into a character array, and
+* mapping each character aka roman digit to its value.
 
 This seems easy with the help of a CLR function:
 
@@ -158,15 +158,15 @@ But as you can see, this won't compile. The red squiggly line tells us there's s
 
 > _convertroman/Program.fs(13,13): Error FS0072: Lookup on object of indeterminate type based on information prior to this program point. A type annotation may be needed prior to this program point to constrain the type of the object. This may allow the lookup to be resolved. (FS0072) (convertroman)_
 
-It refers to line 13 where `digit2value` is defined and complains about not being able to determine the type of the function. The return type is obvious, but what's the type of the parameter `d`? It is used like a character inside the function - but the compiler also looks at how the function is called.
+It refers to line 13 where `digit2value` is defined and complains about not being able to determine the type of the function. The return type is obvious, but what's the type of the parameter `d`? It is used like a character inside the function – but the compiler also looks at how the function is called.
 
-It's called by `Array.map` on array elements - but what is their type? Which leads to the squiggly red line. The compiler does not know what the input array to `map` is about, because it's not sure if `ToCharArray()` can be applied to `roman`.
+It's called by `Array.map` on array elements – but what is their type? This leads to the squiggly red line. The compiler does not know what the input array to `map` is about, because it's not sure if `ToCharArray()` can be applied to `roman`.
 
-Somehow the compiler is not sure whether `roman` really is a `string. That's because in its chain of type inference nowhere it's been made crystal clear (for the compiler's taste at least) that this unambiguously is the case.
+Somehow the compiler is not sure whether `roman` really is a `string`. That's because nowhere in its chain of type inference has it been made crystal clear (for the compiler's taste at least) that this unambiguously is the case.
 
 Maybe you have noticed: So far no explicit type information was given in any code of this tutorial. Values always had a type. But that was inferred automatically by the F# compiler.
 
-F# is a strongly typed language. However that does not mean you have to specify each and every type explicitly. If a type is obvious from a literal's definition, then F# is content with it. From that it can infer the types of values resulting from transformations.
+F# is a strongly typed language. However, that does not mean you have to specify each and every type explicitly. If a type is obvious from a literal's definition, then F# is content with it. From that it can infer the types of values resulting from transformations.
 
 At least mostly. Because as you see, sometimes the type inference engine is confused and needs a little hint.
 
@@ -188,7 +188,7 @@ let (f:int->int) = fun x -> x
 So watch out for the ominous error message _Lookup on object of indeterminate type based..._ If you encounter it, you'll need to apply a type annotation. It's best, then, to keep the scope of the annotation as narrow as possible. Let type inference do the rest. To not use type constraints makes for less coupling and less typing.
 
 ## Solving the negation problem
-The function remaining to be refined is
+The function remaining to be defined is
 
 ```fsharp
 let negate_smaller_values values = // ...
@@ -203,20 +203,20 @@ This can be done with lists, but it seems more natural to use an array for that 
 ```fsharp
 let negate_smaller_values values =
     let nvalues = Array.copy values
-    
+
     [0..nvalues.Length-2]
-    |> List.iter (fun i -> nvalues.[i] <- nvalues.[i] * (if nvalues.[i] < nvalues.[i+1] then -1 else 1)) 
-              
+    |> List.iter (fun i -> nvalues.[i] <- nvalues.[i] * (if nvalues.[i] < nvalues.[i+1] then -1 else 1))
+
     nvalues
 ```
 
 That's why this solution sticks to arrays all the way through. Even though lists were used in the solution design it seems more straightforward to use arrays. At least based on the F# features introduced so far.
 
-Note, that `List.iter` does not refer to the digit values but to a range of indexes given as a list.
+Note that `List.iter` does not refer to the digit values but to a range of indexes given as a list.
 
 And the function stays true to the maxim of immutability. It does not change the input array but copies it before applying negation.
 
-As usual you can find the complete source code in the [repo](src/convertroman/Program.fs).
+As usual, you can find the complete source code in the [repo](src/convertroman/Program.fs).
 
 ***
 
@@ -225,5 +225,4 @@ Only one feature to go. That's tomorrow's topic. And you'll learn more about def
 ### Read more
 * Microsoft, [Operator Overloading (F#)](https://msdn.microsoft.com/en-us/library/dd233204.aspx)
 * Wikibooks, [F Sharp Programming / Operator Overloading](https://en.wikibooks.org/wiki/F_Sharp_Programming/Operator_Overloading)
-
 * Scott Wlaschin, [Understanding type inference](http://fsharpforfunandprofit.com/posts/type-inference/)


### PR DESCRIPTION
The first two weeks of the course. I've fixed dash -> en dash (if you don't like that, tell me and I'll change 'em back), added punctuation for a more natural-looking English, fixed the occasional typo and changed "parameters" to "arguments" where I believe it is more correct (if you want to stick with parameters to keep it simple, let me know).

Oh, and I changed Functional Programming to functional programming. It's fine to capitalize words in titles, but it's not really natural in body text (unless it's a stylistic choice for emphasis, which should be used sparingly). I respect the original author's stylistic choices, of course, so just give me feedback and I'll happily revert any of the more opinionated sets of changes.

I'll continue with the remaining weeks when this PR is done, unless you'd prefer me to stop messing with the text :).
